### PR TITLE
💫 User customable font size feature

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -2,7 +2,7 @@ import { CountingStar } from "react-countingstar";
 
 function App() {
   return (
-    <CountingStar cntNum={37723} time={20} />
+    <CountingStar cntNum={37723} time={4} fontSize={16}/>
   );
 }
 

--- a/src/components/NumberList/container.ts
+++ b/src/components/NumberList/container.ts
@@ -21,7 +21,7 @@ const NumberListSlide = keyframes`
         transform: translateY(0);
     }
     100% {
-        transform: translateY(-9rem);
+        transform: translateY(${-(9 * 100)}%);
     }
 `;
 

--- a/src/main/container.ts
+++ b/src/main/container.ts
@@ -1,13 +1,22 @@
 import styled from "styled-components";
 
+import { cssFontUnitType } from "src/utils/types"
+import { getFontSize } from "src/utils/utils";
+
 export interface CountingStarProps {
   cntNum: number;
   time: number;
+  fontSize: cssFontUnitType | number;
 }
 
-export const CountingStarWrapper = styled.span`
+export interface CountingStarWrapperProps {
+  fontSize: cssFontUnitType | number;
+}
+
+export const CountingStarWrapper = styled.span<CountingStarWrapperProps>`
   display: inline-flex;
   width: fit-content;
-  height: 1rem;
+  height: ${({fontSize}) => getFontSize(fontSize)};
+  font-size: ${({fontSize}) => getFontSize(fontSize)};
   overflow: hidden;
 `;

--- a/src/main/index.tsx
+++ b/src/main/index.tsx
@@ -5,14 +5,14 @@ import { CountingStarProps, CountingStarWrapper } from './container';
 import { NumberList } from "../components/NumberList"
 import { getNumToNumArr, getNumLength } from 'src/utils/utils';
 
-function CountingStar({ cntNum, time }: CountingStarProps) {
+function CountingStar({ cntNum, time, fontSize }: CountingStarProps) {
   const cntNumArr: Array<number> = getNumToNumArr(cntNum);
   const numLength: number = getNumLength(cntNum);
   
   return (
     <>
       <Reset />
-      <CountingStarWrapper>
+      <CountingStarWrapper fontSize={fontSize}>
         {cntNumArr.map((n, idx) => (
           <NumberList 
             key={idx}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,8 @@
+type cssFontAbsoluteLengthUnitTokens = 'cm' | 'mm' | 'in' | 'px' | 'pt' | 'pc';
+type cssFontRelativeLengthUnitTokens = 'em' | 'ex' | 'ch' | 'rem' | 'vw' | 'vmin' | 'vmax' | '%';
+
+/**
+ * css font size units types
+ * @see https://gist.github.com/sunwoo0706/f5562efafa91f7d08d17e26341c850b2
+ */
+export type cssFontUnitType = `${number}${cssFontAbsoluteLengthUnitTokens | cssFontRelativeLengthUnitTokens}`;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,5 @@
+import { cssFontUnitType } from "./types";
+
 /**
  * return number array generated to number.
  * @param number A number what will generated to number[].
@@ -35,4 +37,13 @@ export const getNumLength = (number: number): number => {
  */
  export const getNumListNum = (idx: number, start: number): number => {
     return ((idx + 1) + start) % 10;
+};
+
+/**
+ * return font size customized by the lib user
+ * @param number
+ * @returns If the size is a number, add pixels as a suffix, otherwise return the user-customized size.
+ */
+ export const getFontSize = (fontSize: cssFontUnitType | number): string => {
+    return typeof fontSize === "number" ? fontSize + "px" : fontSize;
 };


### PR DESCRIPTION
## 개요

사용자가 `React-Countingstar` 컴포넌트의 폰트 사이즈를 지정할 수 있는 기능을 추가하였다.

## 작업내용

[cssFontUnitType](https://gist.github.com/sunwoo0706/f5562efafa91f7d08d17e26341c850b2) 에서 유저가 `cssContextUnitsType` 을 제외한 모든 `font-size` 단위를 `React-countingstar` 컴포넌트에서 `prop` 으로 정의할 수 있도록 하였다. `inherit` 방식으로 `font-size` 가 정의하지 못하게 한 이유는 두가지가 있다.

1. **슬롯 카운트 애니메이션이기에 컴포넌트 뷰포트 `height` 를 지정하기가 까다롭다.**

  > 우선 `NumberList` 컴포넌트는 숫자들이 세로로 정렬되어 있고 이를 `overflow: hidden` 으로 해당하지 않는 순번의 숫자가 보이지 않게하는 방식을 로직을 구상하였다. 이렇게 되니 컴포넌트 뷰포트의 `height` 는 당연하게도 `font-size` 와 같은 값을 가져야 하지만 `css` 로는 이를 해결할 수 없었다. 그래서 js를 이용해야 하는데 `inherit` 을 사용하게 되면 useRef로 직접 dom에 접근하여 `current.style.fontSize` 로 체이닝하여 접근하여야 한다. 방식 자체가 까다로울 뿐더라 코드가 더러워지게 된다.

---

2. **`app`의 `cssom`과 별개로 동작하게 만들고 싶다.**

  > 애초에 `inherit` 방식이 마음에 들지 않았다. 부모로부터 상속받은 `font-size` 값을 사용한다는 것은 컴포넌트의 다른 모든 스타일 속성을 사용할 수 있음을 간접적으로 유저에게 알리는것일 뿐더러, 중첩 스타일 방식이나 전역 스타일에 영향을 받게 됨으로써 컴포넌트가 예상치 못한 동작을 일으키게 될 수 있기 때문이다.

##### 이러한 두 가지의 이유로 `prop` 으로 `font-size`를 지정할 수 있게 하였다.
